### PR TITLE
Einheitliche Benamung auch für die Weizen

### DIFF
--- a/Bierliste.md
+++ b/Bierliste.md
@@ -35,9 +35,15 @@ Dampfbier
 
 Dubbel
 
+Dunkles Weizenbier
+
+Helles Weizenbier
+
 India Pale Ale
 
 Kölsch
+
+Kristallweizen
 
 Pale Ale/Ale (2)
 
@@ -56,12 +62,6 @@ Stout
 Strong Ale/Quadrupel
 
 Tripel
-
-Weizenbier (dunkel)
-
-Weizenbier (hell)
-
-Weizenbier (kristall)
 
 Weizenbock
 


### PR DESCRIPTION
Die Weizen waren noch mit Klammer nach Farbe (EBC) unterschieden. Jetzt sollte es einheitlich sein.